### PR TITLE
init vga_text before the rest

### DIFF
--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -8,17 +8,18 @@
 #include <types.h>
 
 void kernel_main(multiboot_info_t* mb_info) {
-    pic_init();
-    idt_init();
-    pit_init(60);
     vga_text_init(mb_info->framebuffer_width, mb_info->framebuffer_height);
 
     vga_text_set_style(VGA_TEXT_COLOR_RED, VGA_TEXT_COLOR_BLACK);
-    
+
+    pic_init();
+    idt_init();
+    pit_init(60);
+
     char buffer[20];
     snprintf(buffer, 20, "Hello, %s!\n", "there");
     vga_text_puts(buffer);
-
+    
     for (;;) {
         asm("hlt");
     }


### PR DESCRIPTION
makes sense for debugging, before you couldn't print e.g. error messages on the screen while initializing things